### PR TITLE
Benchmark qa gen

### DIFF
--- a/samples/financial_transcripts/generate_benchmark_qa.ipynb
+++ b/samples/financial_transcripts/generate_benchmark_qa.ipynb
@@ -1,0 +1,499 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import dotenv_values\n",
+    "\n",
+    "# specify the name of the .env file name \n",
+    "env_name = \"../../llm.env\" # change to your own .env file name\n",
+    "config = dotenv_values(env_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('AnalyzedPDF/ChunksEmbedding.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Id</th>\n",
+       "      <th>Ticker</th>\n",
+       "      <th>Year</th>\n",
+       "      <th>Quarter</th>\n",
+       "      <th>Chunk</th>\n",
+       "      <th>PageNumber</th>\n",
+       "      <th>LineNumber</th>\n",
+       "      <th>Embedding</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>113</th>\n",
+       "      <td>114</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Microsoft FY23 Second Quarter Earnings Confere...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[-0.022043932229280472, -0.023832328617572784,...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>114</th>\n",
+       "      <td>115</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>On the Microsoft Investor Relations website, y...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "      <td>[-0.023697681725025177, -0.005627374164760113,...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>115</th>\n",
+       "      <td>116</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>GAAP. They are included as additional clarifyi...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>17</td>\n",
+       "      <td>[-0.012550131417810917, -0.0020706052891910076...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>116</th>\n",
+       "      <td>117</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>same in constant currency, we will refer to th...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>25</td>\n",
+       "      <td>[-0.017685849219560623, -0.02943631075322628, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>117</th>\n",
+       "      <td>118</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>predictions, projections, or other statements ...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>6</td>\n",
+       "      <td>[-0.00904887169599533, -0.01967030204832554, -...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>216</th>\n",
+       "      <td>217</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>BRETT IVERSEN: Thanks, Brad. Joe, we have time...</td>\n",
+       "      <td>31</td>\n",
+       "      <td>13</td>\n",
+       "      <td>[0.00118646037299186, -0.040140919387340546, 0...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>217</th>\n",
+       "      <td>218</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>the coming quarters? Thank you. SATYA NADELLA:...</td>\n",
+       "      <td>31</td>\n",
+       "      <td>21</td>\n",
+       "      <td>[0.009347211569547653, -0.010082229971885681, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>218</th>\n",
+       "      <td>219</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>going to be an Al app. That's, I think, the be...</td>\n",
+       "      <td>32</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[0.005495850928127766, -0.0035756349097937346,...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>219</th>\n",
+       "      <td>220</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Sometimes, you will have ISVs who are differen...</td>\n",
+       "      <td>32</td>\n",
+       "      <td>9</td>\n",
+       "      <td>[-0.0043395268730819225, -0.02853129617869854,...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>220</th>\n",
+       "      <td>221</td>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>23</td>\n",
+       "      <td>2</td>\n",
+       "      <td>(Operator Direction.) END OF AUDIO *Complete a...</td>\n",
+       "      <td>32</td>\n",
+       "      <td>17</td>\n",
+       "      <td>[-0.017824064940214157, -0.026084331795573235,...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>108 rows × 8 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      Id Ticker  Year  Quarter  \\\n",
+       "113  114   MSFT    23        2   \n",
+       "114  115   MSFT    23        2   \n",
+       "115  116   MSFT    23        2   \n",
+       "116  117   MSFT    23        2   \n",
+       "117  118   MSFT    23        2   \n",
+       "..   ...    ...   ...      ...   \n",
+       "216  217   MSFT    23        2   \n",
+       "217  218   MSFT    23        2   \n",
+       "218  219   MSFT    23        2   \n",
+       "219  220   MSFT    23        2   \n",
+       "220  221   MSFT    23        2   \n",
+       "\n",
+       "                                                 Chunk  PageNumber  \\\n",
+       "113  Microsoft FY23 Second Quarter Earnings Confere...           1   \n",
+       "114  On the Microsoft Investor Relations website, y...           1   \n",
+       "115  GAAP. They are included as additional clarifyi...           1   \n",
+       "116  same in constant currency, we will refer to th...           1   \n",
+       "117  predictions, projections, or other statements ...           2   \n",
+       "..                                                 ...         ...   \n",
+       "216  BRETT IVERSEN: Thanks, Brad. Joe, we have time...          31   \n",
+       "217  the coming quarters? Thank you. SATYA NADELLA:...          31   \n",
+       "218  going to be an Al app. That's, I think, the be...          32   \n",
+       "219  Sometimes, you will have ISVs who are differen...          32   \n",
+       "220  (Operator Direction.) END OF AUDIO *Complete a...          32   \n",
+       "\n",
+       "     LineNumber                                          Embedding  \n",
+       "113           1  [-0.022043932229280472, -0.023832328617572784,...  \n",
+       "114           9  [-0.023697681725025177, -0.005627374164760113,...  \n",
+       "115          17  [-0.012550131417810917, -0.0020706052891910076...  \n",
+       "116          25  [-0.017685849219560623, -0.02943631075322628, ...  \n",
+       "117           6  [-0.00904887169599533, -0.01967030204832554, -...  \n",
+       "..          ...                                                ...  \n",
+       "216          13  [0.00118646037299186, -0.040140919387340546, 0...  \n",
+       "217          21  [0.009347211569547653, -0.010082229971885681, ...  \n",
+       "218           1  [0.005495850928127766, -0.0035756349097937346,...  \n",
+       "219           9  [-0.0043395268730819225, -0.02853129617869854,...  \n",
+       "220          17  [-0.017824064940214157, -0.026084331795573235,...  \n",
+       "\n",
+       "[108 rows x 8 columns]"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df['Quarter']==2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Cosmos DB now supports PostgreSQL, making Azure the first cloud provider to offer a database service that supports both relational and NoSQL workloads. And, in Al, we are turning the world's most advanced models into platforms for customers. Earlier this month, we brought the power of Dall-E to Azure OpenAI service, helping customers like Mattel apply the breakthrough image generation model to commercial use cases for the first time. And Azure Machine Learning provides industry leading MLOps, helping organizations like 3M deploy, manage, and govern models. \""
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df['Chunk'].iloc[11]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Prompt Template\n",
+    "##### Write a Prompt Tempalte. The prompt template should include all filter keys, so they can be referenced and input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "template = \"\"\"\n",
+    "        You are a question answer generator.You are given two chunks of text, a ticker e.g. MSFT, Quarter, Year, as input. You will generate 10 relevant insightful questions and answers grounded in the text. The question should be such that information relevant to answer is available in both the chunks.\n",
+    "               \n",
+    "        An example output for this example is: \n",
+    "\n",
+    "        Question: For {ticker} FY{year} Q{quarter}, what is the growth rate?\n",
+    "        Answer: example answer goes here\n",
+    "\n",
+    "        Based on ticker, quarter, year, the question can be phrased in different ways e.g. MSFT FY23 Q1, MSFT FY2023 1st quarter, e.t.c.\n",
+    "        In case the text question is not relevant, please skip the question and answer pair.\n",
+    "        input_text1: \n",
+    "        {chunk_text1}\n",
+    "        input_text2:\n",
+    "        {chunk_text2}\n",
+    "        ticker: {ticker}\n",
+    "        quarter: {quarter}\n",
+    "        year: {year}\n",
+    "        \"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Randomly pick filter parameters:\n",
+    "\n",
+    "Add Filter Parameters to randomly pick them for extracting context (chunks). This will help diversify generating questions and answers. \n",
+    "In the MSFT Financial Transcripts use-case, the Ticker name is MSFT, but you can easily add other ticker labels for a larger Financial dataset. `Year`,`Quarter`, and `Id` are the key parameters used in this use-case. In this notebook, we are using two random chunks (chunk ids) from specified filter keys (year, quarter).\n",
+    "\n",
+    "###### TODO: Add Tools (an updated version of function calls) once it is available for working with newer models. Function Calls are currently deprecated for gpt models with versions beyond 07-01-2023."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ticker = np.random.choice(df['Ticker'].unique())\n",
+    "Year = np.random.choice(df[df['Ticker']==Ticker]['Year'].unique())\n",
+    "Quarter = np.random.choice(df[(df['Ticker']==Ticker) & (df['Year']==Year)]['Quarter'].unique())\n",
+    "Id = np.random.choice(df[(df['Quarter']==Quarter) & (df['Year']==Year)]['Id'].unique())\n",
+    "Id2 = np.random.choice(df[(df['Quarter']==Quarter) & (df['Year']==Year) & (df['Id']!=Id)]['Id'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'MSFT'"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Ticker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Question 1: How many consumer subscribers did MSFT have, and what was the YoY growth, in the quarter 2 of fiscal year 2023?\n",
+      "Answer: MSFT had more than 63 million consumer subscribers in Q2 FY23, which is a 12 percent YoY growth.\n",
+      "\n",
+      "Question 2: What new offering did MSFT introduce in Q2 FY23?\n",
+      "Answer: MSFT introduced Microsoft 365 \"Basic\" in Q2 FY23, bringing its premium offerings to more people.\n",
+      "\n",
+      "Question 3: What is the total number of monthly active users for Teams in Q2 FY23?\n",
+      "Answer: Teams surpassed 280 million monthly active users in Q2 FY23.\n",
+      "\n",
+      "Question 4: What is MSFT's momentum like for Teams since the pandemic?\n",
+      "Answer: MSFT's momentum for Teams has shown durability since the pandemic, with the platform taking share across every category, from collaboration, to chat, to meetings, to calling.\n",
+      "\n",
+      "Question 5: Which third-party apps had each surpassed half a million active users in Q2 FY23?\n",
+      "Answer: The apps from Adobe, Atlassian, Polly, ServiceNow, and Workday had each surpassed half a million active users in Q2 FY23.\n",
+      "\n",
+      "Question 6: What is the significance of Teams for MSFT?\n",
+      "Answer: Teams has emerged as a first-class platform for MSFT.\n",
+      "\n",
+      "Question 7: What was the focus of ISVs who were optimizing in the last quarter?\n",
+      "Answer: The focus of ISVs who were optimizing in the last quarter was to identify the new set of features to add at what ramp.\n",
+      "\n",
+      "Question 8: What happened in Azure in the last quarter, as mentioned by Amy in her remarks?\n",
+      "Answer: In the last quarter, more long-term customer commitments were added to Azure, as mentioned by Amy in her remarks.\n",
+      "\n",
+      "Question 9: What was the growth rate of MSFT in Q2 FY23?\n",
+      "Answer: The growth rate of MSFT in Q2 FY23 is not mentioned in the given texts.\n",
+      "\n",
+      "Question 10: Can you provide any information on the number of users for third-party apps in Q2 FY23 with less than 10,000 users?\n",
+      "Answer: No, the given text does not provide any information on the number of users for third-party apps in Q2 FY23 with less than 10,000 users.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from openai import AzureOpenAI\n",
+    "\n",
+    "client = AzureOpenAI(\n",
+    "  api_key = config[\"OPENAI_API_KEY\"],  \n",
+    "  api_version = config[\"OPENAI_API_VERSION\"],\n",
+    "  azure_endpoint = config[\"OPENAI_API_BASE\"]\n",
+    ")\n",
+    "\n",
+    "response = client.chat.completions.create(\n",
+    "    model=\"gpt-35-turbo\", # model = \"deployment_name\".\n",
+    "    messages=[\n",
+    "        {\"role\": \"system\", \"content\":\"You are a generator of questions and answers for the given text.\" },\n",
+    "        {\"role\": \"user\", \"content\": template.format(chunk_text1=df['Chunk'].iloc[Id], chunk_text2=df['Chunk'].iloc[Id2], \n",
+    "                                                    ticker=Ticker, year=str(Year), quarter=str(Quarter))}\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "#print(response)\n",
+    "# print(response.model_dump_json(indent=2))\n",
+    "print(response.choices[0].message.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"going to be an Al app. That's, I think, the best way to think about this transformation. On your characterization of the large customers, whether there is any changes in that trajectory, I would point back to, I think, some of the common theme around every large customer is looking to optimize the workload that they have at scale today, and plow some of that money back that they save into new project structure. That's sort of what the classic pattern of large customers is. Sometimes, you will have ISVs who are different, right? If an ISV is optimizing, they optimize and say, what is the new set of features to add at \""
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[(df['Quarter']==Quarter) & (df['Year']==Year) & (df['Id']==Id)].Chunk.values[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['going to be an Al app.',\n",
+       " \"That's, I think, the best way to think about this transformation.\",\n",
+       " 'On your characterization of the large customers, whether there is any changes in that trajectory, I would point back to, I think, some of the common theme around every large customer is looking to optimize the workload that they have at scale today, and plow some of that money back that they save into new project structure.',\n",
+       " \"That's sort of what the classic pattern of large customers is.\",\n",
+       " 'Sometimes, you will have ISVs who are different, right?',\n",
+       " 'If an ISV is optimizing, they optimize and say, what is the new set of features to add at ']"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import re\n",
+    "_pattern = re.compile(r'(?<!\\w\\.\\w.)(?<![A-Z][a-z]\\.)(?<=\\.|\\?)\\s')\n",
+    "retrieved_sentences=_pattern.split(df[(df['Quarter']==Quarter) & (df['Year']==Year) & (df['Id']==Id)].Chunk.values[0])\n",
+    "retrieved_sentences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Question: What does Microsoft Intelligent Data Platform offer to its customers?\\nAnswer: Microsoft Intelligent Data Platform offers a complete data fabric that helps customers cut \"integration tax\" associated with bringing together siloed solutions.\\n\\nQuestion: Which company has standardized on Microsoft\\'s data stack?\\nAnswer: Mercedes-Benz has standardized on Microsoft\\'s data stack to process and govern massive amounts of data.\\n\\nQuestion: What is Cosmos DB powering?\\nAnswer: Cosmos DB is powering the world\\'s most-demanding workloads at limitless scale.\\n\\nQuestion: What makes Azure unique among cloud providers in terms of database service?\\nAnswer: Azure is the first cloud provider to offer a database service that supports both relational and non-relational data models, with Cosmos DB now supporting PostgreSQL.'"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response.choices[0].message.content"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "appliedai",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/samples/financial_transcripts/generate_benchmark_qa.ipynb
+++ b/samples/financial_transcripts/generate_benchmark_qa.ipynb
@@ -3,7 +3,30 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "## Benchmark Question-Answer Generation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how we can generate a set of Questions and Answers based on chunks from a database. Documents chunked before insertion to a database and saved to `.csv` for MSFT transcripts sample. It is beneficial to generate questions and answers at this stage, as doing a search from a database has an added cost. Randomly picking chunks for specified filter parameters ensures diversity of the questions and answers. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SET UP AND CONFIGURATION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load Environment File"
+   ]
   },
   {
    "cell_type": "code",
@@ -19,17 +42,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read Chunks from csv (see step2 notebook from preprocessing subdirectory)"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
     "df = pd.read_csv('AnalyzedPDF/ChunksEmbedding.csv')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -233,7 +265,7 @@
        "[108 rows x 8 columns]"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -244,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -253,7 +285,7 @@
        "\"Cosmos DB now supports PostgreSQL, making Azure the first cloud provider to offer a database service that supports both relational and NoSQL workloads. And, in Al, we are turning the world's most advanced models into platforms for customers. Earlier this month, we brought the power of Dall-E to Azure OpenAI service, helping customers like Mattel apply the breakthrough image generation model to commercial use cases for the first time. And Azure Machine Learning provides industry leading MLOps, helping organizations like 3M deploy, manage, and govern models. \""
       ]
      },
-     "execution_count": 82,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -272,16 +304,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
     "template = \"\"\"\n",
-    "        You are a question answer generator.You are given two chunks of text, a ticker e.g. MSFT, Quarter, Year, as input. You will generate 10 relevant insightful questions and answers grounded in the text. The question should be such that information relevant to answer is available in both the chunks.\n",
+    "        You are a question answer generator.You are given two chunks of text, a ticker e.g. MSFT, Quarter, Year, as input. You will generate 10 relevant questions and answers grounded in the text. The question should be such that the answer is available in both or either of the chunks. They should try to cover most of the information in the text.\n",
     "               \n",
     "        An example output for this example is: \n",
     "\n",
-    "        Question: For {ticker} FY{year} Q{quarter}, what is the growth rate?\n",
+    "        Question: For {ticker} FY{year} Q{quarter}, what is the <question goes here>?\n",
     "        Answer: example answer goes here\n",
     "\n",
     "        Based on ticker, quarter, year, the question can be phrased in different ways e.g. MSFT FY23 Q1, MSFT FY2023 1st quarter, e.t.c.\n",
@@ -310,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -332,7 +364,7 @@
        "'MSFT'"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -342,43 +374,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Generate Questions (using Azure OpenAI only)"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Question 1: How many consumer subscribers did MSFT have, and what was the YoY growth, in the quarter 2 of fiscal year 2023?\n",
-      "Answer: MSFT had more than 63 million consumer subscribers in Q2 FY23, which is a 12 percent YoY growth.\n",
+      "1. What was the percentage increase in server products and cloud services revenue for MSFT in Q1 FY23?\n",
+      "Answer: The server products and cloud services revenue increased by 22% in constant currency for MSFT in Q1 FY23.\n",
       "\n",
-      "Question 2: What new offering did MSFT introduce in Q2 FY23?\n",
-      "Answer: MSFT introduced Microsoft 365 \"Basic\" in Q2 FY23, bringing its premium offerings to more people.\n",
+      "2. How much did Azure and other cloud services revenue grow in constant currency for MSFT in Q1 FY23?\n",
+      "Answer: Azure and other cloud services revenue grew 35% in constant currency for MSFT in Q1 FY23.\n",
       "\n",
-      "Question 3: What is the total number of monthly active users for Teams in Q2 FY23?\n",
-      "Answer: Teams surpassed 280 million monthly active users in Q2 FY23.\n",
+      "3. Did Azure consumption growth meet expectations for MSFT in Q1 FY23?\n",
+      "Answer: No, Azure consumption growth was about a point lower than expected for MSFT in Q1 FY23.\n",
       "\n",
-      "Question 4: What is MSFT's momentum like for Teams since the pandemic?\n",
-      "Answer: MSFT's momentum for Teams has shown durability since the pandemic, with the platform taking share across every category, from collaboration, to chat, to meetings, to calling.\n",
+      "4. What was the impact on the enterprise mobility and security installed base for MSFT in Q1 FY23?\n",
+      "Answer: The enterprise mobility and security installed base grew by 18% to over 232 million seats for MSFT in Q1 FY23.\n",
       "\n",
-      "Question 5: Which third-party apps had each surpassed half a million active users in Q2 FY23?\n",
-      "Answer: The apps from Adobe, Atlassian, Polly, ServiceNow, and Workday had each surpassed half a million active users in Q2 FY23.\n",
+      "5. How did the revenue for MSFT's on-premises server business perform in Q1 FY23?\n",
+      "Answer: The revenue was flat and increased 4% for MSFT's on-premises server business in Q1 FY23.\n",
       "\n",
-      "Question 6: What is the significance of Teams for MSFT?\n",
-      "Answer: Teams has emerged as a first-class platform for MSFT.\n",
+      "6. What was the reason for the decrease in MSFT's margins in Q1 FY23?\n",
+      "Answer: MSFT elected not to throttle back OpEx despite the weakness on the Windows side, which caused margins to drift a little bit lower in Q1 FY23.\n",
       "\n",
-      "Question 7: What was the focus of ISVs who were optimizing in the last quarter?\n",
-      "Answer: The focus of ISVs who were optimizing in the last quarter was to identify the new set of features to add at what ramp.\n",
+      "7. Why did MSFT decide not to throttle back OpEx in Q1 FY23?\n",
+      "Answer: MSFT wanted to continue to invest where they were seeing substantial growth, and they believe it's important to continue investing in those areas.\n",
       "\n",
-      "Question 8: What happened in Azure in the last quarter, as mentioned by Amy in her remarks?\n",
-      "Answer: In the last quarter, more long-term customer commitments were added to Azure, as mentioned by Amy in her remarks.\n",
+      "8. What was the reason for the moderation in Azure consumption growth in Q1 FY23?\n",
+      "Answer: MSFT was helping customers optimize current workloads while they prioritize new workloads, which caused moderation in Azure consumption growth in Q1 FY23.\n",
       "\n",
-      "Question 9: What was the growth rate of MSFT in Q2 FY23?\n",
-      "Answer: The growth rate of MSFT in Q2 FY23 is not mentioned in the given texts.\n",
+      "9. Did MSFT experience a sales mix shift in Q1 FY23?\n",
+      "Answer: Yes, MSFT experienced a little bit more sales mix in Q1 FY23, given the weakness on the Windows side.\n",
       "\n",
-      "Question 10: Can you provide any information on the number of users for third-party apps in Q2 FY23 with less than 10,000 users?\n",
-      "Answer: No, the given text does not provide any information on the number of users for third-party apps in Q2 FY23 with less than 10,000 users.\n"
+      "10. Did MSFT meet their three-months-ago guidance for flat margins in Q1 FY23?\n",
+      "Answer: No, MSFT did not meet their three-months-ago guidance for flat margins in Q1 FY23 as margins drifted a little bit lower.\n"
      ]
     }
    ],
@@ -403,21 +442,23 @@
     "\n",
     "#print(response)\n",
     "# print(response.model_dump_json(indent=2))\n",
-    "print(response.choices[0].message.content)"
+    "print(response.choices[0].message.content)\n",
+    "\n",
+    "#TODO: Add cells showing adding tools to the chat completion. It is an update to functionc calling feature. Function calling feature is not available in the current version of the API.OpenAI version > 1.0.0."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\"going to be an Al app. That's, I think, the best way to think about this transformation. On your characterization of the large customers, whether there is any changes in that trajectory, I would point back to, I think, some of the common theme around every large customer is looking to optimize the workload that they have at scale today, and plow some of that money back that they save into new project structure. That's sort of what the classic pattern of large customers is. Sometimes, you will have ISVs who are different, right? If an ISV is optimizing, they optimize and say, what is the new set of features to add at \""
+       "\"little bit of help there. We did not see as big of that. As I said, it's over 800 for the year. Some of that was in Q1, but the majority of it will be in Q2 through 4. And I think if you want to think about it as somewhere, 250-ish a quarter. It's not exact, but that would be a decent assumption for the remainder of the year. MARK MURPHY, JP Morgan: Thank you. BRETT IVERSEN: Thanks, Mark. Jessi, next question, please. (Operator Direction.) KARL KEIRSTEAD, UBS: Okay, great. Amy, I've love to just ask you around margins. Clearly, you're experiencing a little bit more sales mix, given the \""
       ]
      },
-     "execution_count": 88,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -428,21 +469,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['going to be an Al app.',\n",
-       " \"That's, I think, the best way to think about this transformation.\",\n",
-       " 'On your characterization of the large customers, whether there is any changes in that trajectory, I would point back to, I think, some of the common theme around every large customer is looking to optimize the workload that they have at scale today, and plow some of that money back that they save into new project structure.',\n",
-       " \"That's sort of what the classic pattern of large customers is.\",\n",
-       " 'Sometimes, you will have ISVs who are different, right?',\n",
-       " 'If an ISV is optimizing, they optimize and say, what is the new set of features to add at ']"
+       "['little bit of help there.',\n",
+       " 'We did not see as big of that.',\n",
+       " \"As I said, it's over 800 for the year.\",\n",
+       " 'Some of that was in Q1, but the majority of it will be in Q2 through 4.',\n",
+       " 'And I think if you want to think about it as somewhere, 250-ish a quarter.',\n",
+       " \"It's not exact, but that would be a decent assumption for the remainder of the year.\",\n",
+       " 'MARK MURPHY, JP Morgan: Thank you.',\n",
+       " 'BRETT IVERSEN: Thanks, Mark.',\n",
+       " 'Jessi, next question, please.',\n",
+       " '(Operator Direction.) KARL KEIRSTEAD, UBS: Okay, great.',\n",
+       " \"Amy, I've love to just ask you around margins.\",\n",
+       " \"Clearly, you're experiencing a little bit more sales mix, given the \"]"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -456,20 +503,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'Question: What does Microsoft Intelligent Data Platform offer to its customers?\\nAnswer: Microsoft Intelligent Data Platform offers a complete data fabric that helps customers cut \"integration tax\" associated with bringing together siloed solutions.\\n\\nQuestion: Which company has standardized on Microsoft\\'s data stack?\\nAnswer: Mercedes-Benz has standardized on Microsoft\\'s data stack to process and govern massive amounts of data.\\n\\nQuestion: What is Cosmos DB powering?\\nAnswer: Cosmos DB is powering the world\\'s most-demanding workloads at limitless scale.\\n\\nQuestion: What makes Azure unique among cloud providers in terms of database service?\\nAnswer: Azure is the first cloud provider to offer a database service that supports both relational and non-relational data models, with Cosmos DB now supporting PostgreSQL.'"
+       "['year-over-year.',\n",
+       " 'Excluding the impact of the latest change in accounting estimate, gross margin percentage decreased slightly driven by sales mix shift to cloud offerings.',\n",
+       " 'Operating expense increased 13 percent and 16 percent in constant currency, and operating income increased 10 percent and 19 percent in constant currency, including 4 points due to the latest change in accounting estimate.',\n",
+       " 'Next, the Intelligent Cloud segment.',\n",
+       " 'Revenue was $20.3 billion, increasing 20 percent and 26 percent in constant currency, in line with expectations.',\n",
+       " 'Overall, server products and cloud services revenue increased 22 percent and 28 percent in constant currency.',\n",
+       " 'Azure and other cloud services ']"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
+   "source": [
+    "retrieved_sentences2=_pattern.split(df[(df['Quarter']==Quarter) & (df['Year']==Year) & (df['Id']==Id2)].Chunk.values[0])\n",
+    "retrieved_sentences2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "response.choices[0].message.content"
    ]

--- a/samples/financial_transcripts/step0_data_preprocessor.ipynb
+++ b/samples/financial_transcripts/step0_data_preprocessor.ipynb
@@ -15,9 +15,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Directory 'DATA' created.\n",
+      "MicrosoftEarningReports/MSFTTranscriptFY23Q1.docx\n",
+      "Downloaded: MicrosoftEarningReports/MSFTTranscriptFY23Q1.docx\n",
+      "MicrosoftEarningReports/MSFTTranscriptFY23Q1.pdf\n",
+      "MicrosoftEarningReports/MSFTTranscriptFY23Q2.docx\n",
+      "Downloaded: MicrosoftEarningReports/MSFTTranscriptFY23Q2.docx\n",
+      "MicrosoftEarningReports/MSFTTranscriptFY23Q2.pdf\n",
+      "MicrosoftEarningReports/MSFTTranscriptFY23Q3.docx\n",
+      "Downloaded: MicrosoftEarningReports/MSFTTranscriptFY23Q3.docx\n",
+      "MicrosoftEarningReports/MSFTTranscriptFY23Q3.pdf\n",
+      "MicrosoftEarningReports/MSFTTranscriptFY23Q4.docx\n",
+      "Downloaded: MicrosoftEarningReports/MSFTTranscriptFY23Q4.docx\n",
+      "MicrosoftEarningReports/MSFTTranscriptFY23Q4.pdf\n",
+      "MicrosoftEarningReports/README.md\n"
+     ]
+    }
+   ],
    "source": [
     "from azure.storage.blob import BlobServiceClient\n",
     "import os\n",
@@ -28,6 +49,13 @@
     "\n",
     "# Local directory path to save the downloaded files\n",
     "local_directory = Path(\"DATA/\")\n",
+    "# Check if the directory exists\n",
+    "if not local_directory.is_dir():\n",
+    "    # If it doesn't exist, create it\n",
+    "    local_directory.mkdir(parents=True, exist_ok=True)\n",
+    "    print(f\"Directory '{local_directory}' created.\")\n",
+    "else:\n",
+    "    print(f\"Directory '{local_directory}' already exists.\")\n",
     "\n",
     "def download_files_from_blob_storage(container_name, local_directory):\n",
     "    # Create a BlobServiceClient using the default credentials (public access)\n",
@@ -70,9 +98,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4\n"
+     ]
+    }
+   ],
    "source": [
     "from docx2pdf import convert\n",
     "import os\n",
@@ -86,9 +122,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Skipping conversion for MSFTTranscriptFY23Q1.docx. PDF already exists.\n",
+      "Skipping conversion for MSFTTranscriptFY23Q2.docx. PDF already exists.\n",
+      "Skipping conversion for MSFTTranscriptFY23Q3.docx. PDF already exists.\n",
+      "Skipping conversion for MSFTTranscriptFY23Q4.docx. PDF already exists.\n"
+     ]
+    }
+   ],
    "source": [
     "for filename in docx_files:\n",
     "    \n",


### PR DESCRIPTION
Added a notebook  `generate_benchmark_qa.ipynb`. This notebook works with more recent version of Azure openai 1.6.1. It does not require additional frameworks such as langchain, to derisk the langchain update intricacies. It should work with previous version of Azure openai (<1.0.0) also, that was used for other purposes in this repo.

There is a prompt template presented that allows using filter parameters. and context texts based on chunks of data. It can be further iterated. Note: Azure OpenAI function call is deprecated in more recent versions, and we want to use tools feature once we have a newer version deployed. (I tested tools with 12-01-2023 preview version, and it doesn't seem to work. We can revisit this later.)

Please run the notebook, and check that each cell works. The notebook shows 10 questions, but more can be generated. Experimentation  might be required for further refinement.